### PR TITLE
add laerke-eu-pressure-reading-plugin to plugins.json

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -63,5 +63,11 @@
         "author": "Pioreactor",
         "homepage": "https://github.com/Pioreactor/temperature-expansion-kit-plugin",
         "description": "Expand the Pioreactor's temperature performance. Additional hardware kit required!"
+    },
+    {
+        "name": "laerke-eu-pressure-reading-plugin",
+        "author": "Laerke.eu",
+        "homepage": "https://www.laerke.eu",
+        "description": "A pressure sensor system for online tracking and analysis of gas formation or consumption in vials."
     }
 ]


### PR DESCRIPTION
This is a plugin for the Laerke.eu pressure sensor. It is not possible to buy the Laerke.eu pressure sensor yet. But it will be soon. for now it will be used by some beta testers.